### PR TITLE
Only print port when VERBOSE is on

### DIFF
--- a/piescan.py
+++ b/piescan.py
@@ -97,6 +97,7 @@ def tcp_scan((target, port)):
            ports_ident["filtered"].append(port)
  	            
 	else:
+            if VERBOSE:
 		print port
     except socket.timeout:
 	ports_ident["filtered"].append(port)


### PR DESCRIPTION
Ports are printed to the console when the return is not 0, 111 or 11.